### PR TITLE
chore: deprecate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ moved {
 ```
 
 **3. Run `tf plan`** (`tf` being Terraform or OpenTofu) - verify resources show as "moved" (not destroyed/created)
+
 **4. Run `tf apply`** (`tf` being Terraform or OpenTofu)
+
 **5. Remove `moved` blocks** after successful migration
 
 ---

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### Migration (Without Recreating Resources)
 
-If you'd like to migrate from using this module to using the `spacelift_aws_integration` resource directly without recreating resources, follow these steps:
+If you are using the same root module with existing current TF state and you'd like to migrate from using this module to using the `spacelift_aws_integration` resource directly without recreating resources, follow these steps:
 
 **1. Replace module with resources:**
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,53 @@
 
 # terraform-spacelift-aws-integrations
 
+## ⚠️ ARCHIVED - IMPORTANT: Module D
+
+**This module is no longer maintained.** We recommend using the [`spacelift_aws_integration`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/aws_integration) resource directly instead.
+
+**Why?** We realized this module was such a thin wrapper around the Terraform/OpenTofu resource that for simplicity, better clarity with less abstraction, the same came be accomplished by using the resource directly in your modules.
+
+### Migration (Without Recreating Resources)
+If you'd like to migrate from using this module to using the `spacelift_aws_integration` resource directly without recreating resources, follow these steps:
+
+**1. Replace module with resources:**
+```hcl
+# Before
+module "spacelift_aws_integrations" {
+  source = "masterpointio/spacelift/aws-integrations"
+
+  aws_integrations = {
+    "prod" = {
+      aws_account_id = "123456789012"
+      role_arn       = "arn:aws:iam::123456789012:role/spacelift"
+      labels         = ["prod"]
+    }
+  }
+}
+
+# After
+resource "spacelift_aws_integration" "prod" {
+  name           = "prod-123456789012"
+  aws_account_id = "123456789012"
+  role_arn       = "arn:aws:iam::123456789012:role/spacelift"
+  labels         = ["prod"]
+}
+```
+
+**2. Add `moved` blocks to prevent recreation:**
+```hcl
+moved {
+  from = module.spacelift_aws_integrations.spacelift_aws_integration.this["prod"]
+  to   = spacelift_aws_integration.prod
+}
+```
+
+**3. Run `tf plan`** (`tf` being Terraform or OpenTofu) - verify resources show as "moved" (not destroyed/created)
+**4. Run `tf apply`** (`tf` being Terraform or OpenTofu)
+**5. Remove `moved` blocks** after successful migration
+
+---
+
 [![Release][release-badge]][latest-release]
 
 💡 Learn more about Masterpoint [below](#who-we-are-𐦂𖨆𐀪𖠋).

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 **Why?** We realized this module was such a thin wrapper around the Terraform/OpenTofu resource that for simplicity, better clarity with less abstraction, the same came be accomplished by using the resource directly in your modules.
 
 ### Migration (Without Recreating Resources)
+
 If you'd like to migrate from using this module to using the `spacelift_aws_integration` resource directly without recreating resources, follow these steps:
 
 **1. Replace module with resources:**
+
 ```hcl
 # Before
 module "spacelift_aws_integrations" {
@@ -36,6 +38,7 @@ resource "spacelift_aws_integration" "prod" {
 ```
 
 **2. Add `moved` blocks to prevent recreation:**
+
 ```hcl
 moved {
   from = module.spacelift_aws_integrations.spacelift_aws_integration.this["prod"]

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # terraform-spacelift-aws-integrations
 
-## ⚠️ ARCHIVED - IMPORTANT: Module D
+## ⚠️ ARCHIVED - IMPORTANT: Module Deprecated
 
 **This module is no longer maintained.** We recommend using the [`spacelift_aws_integration`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/aws_integration) resource directly instead.
 
-**Why?** We realized this module was such a thin wrapper around the Terraform/OpenTofu resource that for simplicity, better clarity with less abstraction, the same came be accomplished by using the resource directly in your modules.
+**Why?** We realized this module was such a thin wrapper around the Terraform/OpenTofu resource that for simplicity, better clarity with less abstraction, the same can be accomplished by using the resource directly in your modules.
 
 ### Migration (Without Recreating Resources)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ moved {
 
 **4. Run `tf apply`** (`tf` being Terraform or OpenTofu)
 
-**5. Remove `moved` blocks** after successful migration
+**5. Remove `moved` blocks after successful migration**
 
 ---
 


### PR DESCRIPTION
This task is to clean up and likely deprecate/archive the spacelift-aws-integration module, and instead manage the Spacelift AWS Integration directly in the appropriate root module where it’s used.

### Why

- The module is very small and adds maintenance overhead without clear benefit.
- Integrations have a different lifecycle than automation and are often better managed at the root-module level for each environment/account.

### Slack discussion (source)

- 2025‑07‑01 — Discussion about archiving the repo and managing the integration in root modules: <[https://masterpoint.slack.com/archives/C04MUCKUDKK/p1751401578555369?thread_ts=1751401578.555369&cid=C04MUCKUDKK|Thread](https://masterpoint.slack.com/archives/C04MUCKUDKK/p1751401578555369?thread_ts=1751401578.555369&cid=C04MUCKUDKK%7CThread) start> • Follow‑ups: <https://masterpoint.slack.com/archives/C04MUCKUDKK/p1751401602377729?thread_ts=1751401578.555369&cid=C04MUCKUDKK> · <https://masterpoint.slack.com/archives/C04MUCKUDKK/p1751448976579339?thread_ts=1751401578.555369&cid=C04MUCKUDKK> · <https://masterpoint.slack.com/archives/C04MUCKUDKK/p1757526351811829?thread_ts=1751401578.555369&cid=C04MUCKUDKK>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added archival notice to the README clearly marking the module as archived and directing users to updated resources and alternatives for continued support
  * Included comprehensive migration guide featuring step-by-step instructions, detailed configuration patterns, and practical code examples to facilitate seamless transition from the current module to the new spacelift_aws_integration resource

<!-- end of auto-generated comment: release notes by coderabbit.ai -->